### PR TITLE
Add(parse) repo reference URL for the module

### DIFF
--- a/msf/msf.go
+++ b/msf/msf.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -210,6 +211,10 @@ func Parse(file []byte, path string) (*models.Module, error) {
 		}
 	}
 
+	// Module Repository URL
+	moduleURL := FormatModuleURL(path)
+	links = append(links, moduleURL)
+
 	return &models.Module{
 		Name:        filepath.Base(path),
 		Title:       title,
@@ -256,4 +261,14 @@ func FormatReferences(refType string, refID string) string {
 	}
 
 	return url
+}
+
+// FormatModuleURL :
+func FormatModuleURL(path string) string {
+	// remove cache dir strings
+	s := strings.SplitAfter(path, "metasploit-framework")
+	u, _ := url.Parse("https://github.com/rapid7/metasploit-framework/blob/master")
+	u.Path = filepath.Join(u.Path, s[len(s)-1])
+
+	return u.String()
 }

--- a/msf/msf_test.go
+++ b/msf/msf_test.go
@@ -188,6 +188,10 @@ func TestFormatModuleURL(t *testing.T) {
 			"https://github.com/rapid7/metasploit-framework/blob/master/modules/example.rb",
 		},
 		{
+			"/home/runner/.cache/msfdb-list-updater/metasploit-framework/modules/example.rb",
+			"https://github.com/rapid7/metasploit-framework/blob/master/modules/example.rb",
+		},
+		{
 			"modules/example.rb",
 			"https://github.com/rapid7/metasploit-framework/blob/master/modules/example.rb",
 		},

--- a/msf/msf_test.go
+++ b/msf/msf_test.go
@@ -20,6 +20,9 @@ func TestParse(t *testing.T) {
 			module: &models.Module{
 				Name:  "test_000.rb",
 				Title: "Sample Module",
+				References: []string{
+					"https://github.com/rapid7/metasploit-framework/blob/master/testdata/test_000.rb",
+				},
 			},
 		},
 		{
@@ -39,6 +42,7 @@ func TestParse(t *testing.T) {
 					"http://www.kb.cert.org/vuls/id/12345",
 					"https://packetstormsecurity.com/files/12345",
 					"http://www.example.com",
+					"https://github.com/rapid7/metasploit-framework/blob/master/testdata/test_001.rb",
 				},
 			},
 		},
@@ -48,6 +52,9 @@ func TestParse(t *testing.T) {
 				Name:        "test_002.rb",
 				Title:       "Sample Auxiliary",
 				Description: "Sample Auxiliary Module",
+				References: []string{
+					"https://github.com/rapid7/metasploit-framework/blob/master/testdata/test_002.rb",
+				},
 			},
 		},
 		{
@@ -62,6 +69,7 @@ func TestParse(t *testing.T) {
 					"https://googleprojectzero.blogspot.com/2019/11/bad-binder-android-in-wild-exploit.html",
 					"https://hernan.de/blog/2019/10/15/tailoring-cve-2019-2215-to-achieve-root/",
 					"https://github.com/grant-h/qu1ckr00t/blob/master/native/poc.c",
+					"https://github.com/rapid7/metasploit-framework/blob/master/testdata/test_003.rb",
 				},
 			},
 		},
@@ -74,6 +82,7 @@ func TestParse(t *testing.T) {
 				CveIDs:      []string{"CVE-2018-17179"},
 				References: []string{
 					"https://github.com/openemr/openemr/commit/3e22d11c7175c1ebbf3d862545ce6fee18f70617",
+					"https://github.com/rapid7/metasploit-framework/blob/master/testdata/test_004.rb",
 				},
 			},
 		},
@@ -159,6 +168,33 @@ func TestFormatReferences(t *testing.T) {
 
 	for _, tt := range tests {
 		actual := msf.FormatReferences(tt.inType, tt.inID)
+		if actual != tt.out {
+			t.Errorf("\n got: %s\nwant: %s", tt.out, actual)
+		}
+	}
+}
+
+func TestFormatModuleURL(t *testing.T) {
+	var tests = []struct {
+		in  string
+		out string
+	}{
+		{
+			"",
+			"https://github.com/rapid7/metasploit-framework/blob/master",
+		},
+		{
+			"User/Caches/msfdb-list-updater/metasploit-framework/modules/example.rb",
+			"https://github.com/rapid7/metasploit-framework/blob/master/modules/example.rb",
+		},
+		{
+			"modules/example.rb",
+			"https://github.com/rapid7/metasploit-framework/blob/master/modules/example.rb",
+		},
+	}
+
+	for _, tt := range tests {
+		actual := msf.FormatModuleURL(tt.in)
 		if actual != tt.out {
 			t.Errorf("\n got: %s\nwant: %s", tt.out, actual)
 		}


### PR DESCRIPTION
New URL information added to the References

# What did you implement:

- Associate the msf module with GitHub URL
- Test for GitHub URL formating

# How Has This Been Tested?

```
$ make test
fatal: No names found, cannot describe anything.
GO111MODULE=off go get -u golang.org/x/lint/golint
golint github.com/vulsio/msfdb-list-updater github.com/vulsio/msfdb-list-updater/git github.com/vulsio/msfdb-list-updater/log github.com/vulsio/msfdb-list-updater/models github.com/vulsio/msfdb-list-updater/msf github.com/vulsio/msfdb-list-updater/utils
echo github.com/vulsio/msfdb-list-updater github.com/vulsio/msfdb-list-updater/git github.com/vulsio/msfdb-list-updater/log github.com/vulsio/msfdb-list-updater/models github.com/vulsio/msfdb-list-updater/msf github.com/vulsio/msfdb-list-updater/utils | xargs env GO111MODULE=on go vet || exit;
gofmt -d git/git.go; gofmt -d log/log.go; gofmt -d main.go; gofmt -d models/type.go; gofmt -d msf/msf.go; gofmt -d msf/msf_test.go; gofmt -d utils/last_updated.go; gofmt -d utils/utils.go;
GO111MODULE=on go test -cover -v ./... || exit;
?   	github.com/vulsio/msfdb-list-updater	[no test files]
?   	github.com/vulsio/msfdb-list-updater/git	[no test files]
?   	github.com/vulsio/msfdb-list-updater/log	[no test files]
?   	github.com/vulsio/msfdb-list-updater/models	[no test files]
=== RUN   TestParse
=== RUN   TestParse/test_000.rb
=== RUN   TestParse/test_001.rb
=== RUN   TestParse/test_002.rb
=== RUN   TestParse/test_003.rb
=== RUN   TestParse/test_004.rb
--- PASS: TestParse (0.00s)
    --- PASS: TestParse/test_000.rb (0.00s)
    --- PASS: TestParse/test_001.rb (0.00s)
    --- PASS: TestParse/test_002.rb (0.00s)
    --- PASS: TestParse/test_003.rb (0.00s)
    --- PASS: TestParse/test_004.rb (0.00s)
=== RUN   TestFormatDescription
--- PASS: TestFormatDescription (0.00s)
=== RUN   TestFormatReferences
--- PASS: TestFormatReferences (0.00s)
=== RUN   TestFormatModuleURL
--- PASS: TestFormatModuleURL (0.00s)
PASS
coverage: 55.6% of statements
ok  	github.com/vulsio/msfdb-list-updater/msf	(cached)	coverage: 55.6% of statements
?   	github.com/vulsio/msfdb-list-updater/utils	[no test files]
```

# Others

### msfdb-list

```
$ bat msfdb-list/rapid7/2020/CVE-2020-4429.json
───────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: msfdb-list/rapid7/2020/CVE-2020-4429.json
───────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ [
   2   │   {
   3   │     "Name": "ibm_drm_download.rb",
   4   │     "Title": "IBM Data Risk Manager Arbitrary File Download",
   5   │     "Description": "IBM Data Risk Manager (IDRM) contains two vulnerabilities that can be chained by an unauthenticated attacker to download arbitrary files off the system. The first is an unauthenticated bypass, followed by a pa
       │ th traversal. This module exploits both vulnerabilities, giving an attacker the ability to download (non-root) files. A downloaded file is zipped, and this module also unzips it before storing it in the database. By default this
       │ module downloads Tomcat's application.properties files, which contains the database password, amongst other sensitive data. At the time of disclosure, this is was a 0 day, but IBM later patched it and released their advisory. Ver
       │ sions 2.0.2 to 2.0.4 are vulnerable, version 2.0.1 is not.",
   6   │     "CveIDs": [
   7   │       "CVE-2020-4427",
   8   │       "CVE-2020-4429"
   9   │     ],
  10   │     "References": [
  11   │       "https://github.com/pedrib/PoC/blob/master/advisories/IBM/ibm_drm/ibm_drm_rce.md",
  12   │       "https://seclists.org/fulldisclosure/2020/Apr/33",
  13   │       "https://www.ibm.com/blogs/psirt/security-bulletin-vulnerabilities-exist-in-ibm-data-risk-manager-cve-2020-4427-cve-2020-4428-cve-2020-4429-and-cve-2020-4430/",
  14   │       "https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/admin/http/ibm_drm_download.rb"
  15   │     ]
  16   │   },
  17   │   {
  18   │     "Name": "ibm_drm_rce.rb",
  19   │     "Title": "IBM Data Risk Manager Unauthenticated Remote Code Execution",
  20   │     "Description": "IBM Data Risk Manager (IDRM) contains three vulnerabilities that can be chained by an unauthenticated attacker to achieve remote code execution as root. The first is an unauthenticated bypass, followed by a co
       │ mmand injection as the server user, and finally abuse of an insecure default password. This module exploits all three vulnerabilities, giving the attacker a root shell. At the time of disclosure this was an 0day, but it was later
       │  confirmed and patched by IBM. The authentication bypass works on versions <= 2.0.6.1, but the command injection should only work on versions <= 2.0.4 according to IBM.",
  21   │     "CveIDs": [
  22   │       "CVE-2020-4427",
  23   │       "CVE-2020-4428",
  24   │       "CVE-2020-4429"
  25   │     ],
  26   │     "References": [
  27   │       "https://github.com/pedrib/PoC/blob/master/advisories/IBM/ibm_drm/ibm_drm_rce.md",
  28   │       "https://seclists.org/fulldisclosure/2020/Apr/33",
  29   │       "https://www.ibm.com/blogs/psirt/security-bulletin-vulnerabilities-exist-in-ibm-data-risk-manager-cve-2020-4427-cve-2020-4428-cve-2020-4429-and-cve-2020-4430/",
  30   │       "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/ibm_drm_rce.rb"
  31   │     ]
  32   │   },
  33   │   {
  34   │     "Name": "ibm_drm_a3user.rb",
  35   │     "Title": "IBM Data Risk Manager a3user Default Password",
  36   │     "Description": "This module abuses a known default password in IBM Data Risk Manager. The 'a3user' has the default password 'idrm' and allows an attacker to log in to the virtual appliance via SSH. This can be escalate to ful
       │ l root access, as 'a3user' has sudo access with the default password. At the time of disclosure this was an 0day, but it was later confirmed and patched by IBM. Versions <= 2.0.6.1 are confirmed to be vulnerable.",
  37   │     "CveIDs": [
  38   │       "CVE-2020-4429"
  39   │     ],
  40   │     "References": [
  41   │       "https://github.com/pedrib/PoC/blob/master/advisories/IBM/ibm_drm/ibm_drm_rce.md",
  42   │       "https://seclists.org/fulldisclosure/2020/Apr/33",
  43   │       "https://www.ibm.com/blogs/psirt/security-bulletin-vulnerabilities-exist-in-ibm-data-risk-manager-cve-2020-4427-cve-2020-4428-cve-2020-4429-and-cve-2020-4430/",
  44   │       "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/ssh/ibm_drm_a3user.rb"
  45   │     ]
  46   │   }
  47   │ ]
───────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```